### PR TITLE
RESTClient: Update link, add repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you wish to contribute: [start a pull request](https://github.com/stepci/awes
 ## IDE
 
 - [VS Code REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) ([repo](https://github.com/Huachao/vscode-restclient)) - Send HTTP request and view the response in Visual Studio Code
-- [RESTClient](https://addons.mozilla.org/en-US/firefox/addon/restclient/) - A Firefox debugger for RESTful web services
+- [RESTClient](http://restclient.net/) ([repo](https://github.com/chao/RESTClient)) - A debugger for RESTful web services
 - [restclient.el](https://github.com/pashky/restclient.el) - HTTP REST client tool for emacs
 - [verb](https://github.com/federicotdn/verb) - Organize and send HTTP requests from Emacs
 


### PR DESCRIPTION
Updating link for RESTClient and adding link for repo since RESTClient add-on for Firefox not more available:

- [RESTClient, a debugger for RESTful web services, has been blocked for your protection.](https://addons.mozilla.org/en-US/firefox/blocked-addon/%7Bad0d925d-88f8-47f1-85ea-8463569e756e%7D/3.0.8/)
- chao/RESTClient#365