### PR TITLE
Remove Firefox RestClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ If you wish to contribute: [start a pull request](https://github.com/stepci/awes
 ## IDE
 
 - [VS Code REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) ([repo](https://github.com/Huachao/vscode-restclient)) - Send HTTP request and view the response in Visual Studio Code
-- [RESTClient](https://addons.mozilla.org/en-US/firefox/addon/restclient/) - A Firefox debugger for RESTful web services
 - [restclient.el](https://github.com/pashky/restclient.el) - HTTP REST client tool for emacs
 - [verb](https://github.com/federicotdn/verb) - Organize and send HTTP requests from Emacs
 - [rest.nvim](https://github.com/rest-nvim/rest.nvim) - A fast Neovim http client written in Lua


### PR DESCRIPTION
## Why?

- The link to https://addons.mozilla.org/en-US/firefox/addon/restclient/ 404s
  - Seems that it was delisted between [May 19th 2024](https://web.archive.org/web/20240519025712/https://addons.mozilla.org/en-US/firefox/addon/restclient/) and [August 6th 2024](https://web.archive.org/web/20240806202703/https://addons.mozilla.org/en-US/firefox/addon/restclient/)
- The repo hasn't been updated in 7 years https://github.com/chao/RESTClient

Thanks!
